### PR TITLE
feat(docs): exclude docusaurus server from dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write .",
     "lint": "turbo run lint -- --fix",
     "test": "turbo run test",
-    "dev": "turbo run dev",
+    "dev": "turbo run dev --filter=!docs",
     "docs:dev": "turbo run dev --filter=docs",
     "docs:build": "turbo run build --filter=docs",
     "docs:clean": "turbo run clean --filter=docs"

--- a/turbo.json
+++ b/turbo.json
@@ -33,6 +33,24 @@
       "cache": false,
       "dependsOn": ["^build"],
       "persistent": true
+    },
+    "docs:dev": {
+      "cache": false,
+      "dependsOn": ["docs:build"],
+      "persistent": true
+    },
+    "docs:build": {
+      "inputs": [
+        "tsconfig.json",
+        "tsconfig.base.json",
+        "vite.config.ts",
+        "src/**"
+      ],
+      "outputs": ["dist/**", "build/**"],
+      "dependsOn": ["^clean", "^build"]
+    },
+    "docs:clean": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Prevent Docusaurus server when `pnpm dev` is run. Docusaurus does not need to run most of the time when developing.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
