### PR TITLE
feat(sdk): add browser wallet errors

### DIFF
--- a/apps/docs/docs/api/browser-wallets.mdx
+++ b/apps/docs/docs/api/browser-wallets.mdx
@@ -84,9 +84,13 @@ connectToWallet();
 
 Indicates whether the browser wallet extension is installed.
 
-Returns: `boolean`
+**Returns**: `boolean`
 
-Output Example: `true | false`
+**Output Example**: `true | false`
+
+**Throws**:
+
+- `OrditSDKError` Function is called outside a browser without `window` object
 
 ### getAddresses
 
@@ -94,13 +98,13 @@ Output Example: `true | false`
 
 Gets a list of addresses for the browser wallet if authorized.
 
-Parameters:
+**Parameters**:
 
 - `network` : `"mainnet" | "testnet"` (defaults to `mainnet`)
 
-Returns: `Promise<WalletAddress[]>`
+**Returns**: `Promise<WalletAddress[]>`
 
-Output Example:
+**Output Example**:
 
 ```bash
 [
@@ -113,22 +117,26 @@ Output Example:
 ];
 ```
 
+**Throws**:
+
+- `BrowserWalletNotInstalledError` Wallet is not installed
+
 ### signPsbt
 
 `signPsbt(psbt[, options])`
 
 Signs a Partially Signed Bitcoin Transaction (PSBT) and returns a signature.
 
-Parameters:
+**Parameters**:
 
 - `psbt` : `string` in hex or base64 format
 - `options` : `object` (optional)
   - `extractTx` : Extract transaction (defaults to `true`)
   - `finalize` : Finalize signing (defaults to `true`)
 
-Returns: `Promise<BrowserWalletSignResponse>`
+**Returns**: `Promise<BrowserWalletSignResponse>`
 
-Output Example:
+**Output Example**:
 
 ```bash
 {
@@ -136,6 +144,11 @@ Output Example:
   hex: "70736274ff01000a02000000000000000000000000",
 }
 ```
+
+**Throws**:
+
+- `BrowserWalletNotInstalledError` Wallet is not installed
+- `BrowserWalletSigningError` Signing failed
 
 ### signMessage
 
@@ -143,13 +156,13 @@ Output Example:
 
 Signs a message and returns a signature.
 
-Parameters:
+**Parameters**:
 
 - `message` : `string`
 
-Returns: `Promise<BrowserWalletSignResponse>`
+**Returns**: `Promise<BrowserWalletSignResponse>`
 
-Output Example:
+**Output Example**:
 
 ```bash
 {
@@ -157,3 +170,8 @@ Output Example:
   hex: "70736274ff01000a02000000000000000000000000",
 }
 ```
+
+**Throws**:
+
+- `BrowserWalletNotInstalledError` Wallet is not installed
+- `BrowserWalletSigningError` Signing failed

--- a/packages/sdk/src/errors/index.ts
+++ b/packages/sdk/src/errors/index.ts
@@ -4,3 +4,17 @@ export class OrditSDKError extends Error {
     this.name = "OrditSDKError";
   }
 }
+
+export class BrowserWalletNotInstalledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrowserWalletNotInstalledError";
+  }
+}
+
+export class BrowserWalletSigningError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrowserWalletSigningError";
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Adds browser wallet errors. `ord-connect` is currently checking against error message strings which is prone to breaking changes.
- Adds documentation to what each method can throw.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Additional comments?:
