### PR TITLE
feat(sdk): add readOnly parameter to browser wallet getAddresses

### DIFF
--- a/packages/sdk/src/browser-wallets/unisat/index.ts
+++ b/packages/sdk/src/browser-wallets/unisat/index.ts
@@ -22,10 +22,12 @@ function isInstalled() {
  * Gets addresses from the browser wallet.
  *
  * @param network Network
+ * @param readOnly Read only (when set to true, the wallet modal appears)
  * @returns An array of WalletAddress objects.
  */
 async function getAddresses(
   network: BrowserWalletNetwork = "mainnet",
+  readOnly?: boolean,
 ): Promise<WalletAddress[]> {
   if (!isInstalled()) {
     throw new OrditSDKError("Unisat not installed");
@@ -41,7 +43,9 @@ async function getAddresses(
     await window.unisat.switchNetwork(targetNetwork);
   }
 
-  const accounts = await window.unisat.requestAccounts();
+  const accounts = readOnly
+    ? await window.unisat.getAccounts()
+    : await window.unisat.requestAccounts();
   const publicKey = await window.unisat.getPublicKey();
 
   const address = accounts[0];

--- a/packages/sdk/src/browser-wallets/xverse/index.ts
+++ b/packages/sdk/src/browser-wallets/xverse/index.ts
@@ -20,10 +20,12 @@ function isInstalled() {
  * Gets addresses from the browser wallet.
  *
  * @param network Network
+ * @param readOnly Read only (when set to true, the wallet modal appears)
  * @returns An array of WalletAddress objects.
  */
 async function getAddresses(
   _network: BrowserWalletNetwork = "mainnet",
+  _readOnly?: boolean,
 ): Promise<WalletAddress[]> {
   return [];
 }

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -9,6 +9,7 @@ type Unisat = {
   getNetwork: () => Promise<UnisatNetwork>;
   switchNetwork: (targetNetwork: UnisatNetwork) => Promise<void>;
   requestAccounts: () => Promise<string[]>;
+  getAccounts: () => Promise<string[]>;
   getPublicKey: () => Promise<string>;
   signPsbt: (
     hex: string,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Add `readOnly` parameter to browser wallet getAddresses

@kainanaina 
> As per docs (https://docs.unisat.io/dev/unisat-wallet-api#getaccounts) unisat got 2 methods, one is requestAccounts and another is getAccounts. They both returning same results, but request version comes with a side-effect that also opens wallet connect if you are not connected. That results in a major UX issue in case any app wants to call this method to update addresses in the background, which results in constantly opening wallet, when it's technically not required. This param allows optionally calling readOnly version of that method, without breaking existing connection logic anywhere else.

#### Which issue(s) does this PR fixes?:

#### Additional comments?:
