### PR TITLE
feat(unisat): extend message signer to accept type

### DIFF
--- a/apps/docs/docs/api/browser-wallets.mdx
+++ b/apps/docs/docs/api/browser-wallets.mdx
@@ -152,13 +152,14 @@ Signs a Partially Signed Bitcoin Transaction (PSBT) and returns a signature.
 
 ### signMessage
 
-`signMessage(message)`
+`signMessage(message[, type])`
 
 Signs a message and returns a signature.
 
 **Parameters**:
 
 - `message` : `string`
+- `type` : `"bip322-simple" | "ecdsa"` (defaults to `ecdsa`)
 
 **Returns**: `Promise<BrowserWalletSignResponse>`
 

--- a/packages/sdk/src/browser-wallets/unisat/index.ts
+++ b/packages/sdk/src/browser-wallets/unisat/index.ts
@@ -107,18 +107,20 @@ async function signPsbt(
  * Signs a message.
  *
  * @param message Message to be signed
+ * @param type Signature type
  * @returns An object containing `base64` and `hex`.
  * @throws {BrowserWalletNotInstalledError} Wallet is not installed
  * @throws {BrowserWalletSigningError} Signing failed
  */
 async function signMessage(
   message: string,
+  type: MessageSignatureTypes = "ecdsa",
 ): Promise<BrowserWalletSignResponse> {
   if (!isInstalled()) {
     throw new BrowserWalletNotInstalledError("Unisat not installed");
   }
 
-  const signature = await window.unisat.signMessage(message);
+  const signature = await window.unisat.signMessage(message, type);
 
   if (!signature) {
     throw new BrowserWalletSigningError("Failed to sign message using Unisat");

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -5,6 +5,8 @@ declare interface Window {
 
 type UnisatNetwork = "livenet" | "testnet";
 
+type MessageSignatureTypes = "bip322-simple" | "ecdsa";
+
 type Unisat = {
   getNetwork: () => Promise<UnisatNetwork>;
   switchNetwork: (targetNetwork: UnisatNetwork) => Promise<void>;
@@ -15,7 +17,10 @@ type Unisat = {
     hex: string,
     { autoFinalized }: Record<string, boolean>,
   ) => Promise<string>;
-  signMessage: (message: string) => Promise<string>;
+  signMessage: (
+    message: string,
+    type: MessageSignatureTypes,
+  ) => Promise<string>;
 };
 
 type MetaMask = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

> This PR extends the Unisat message signer to accept signature type.
> 
> With the latest addition of `bip322` in #91 to enable message signing and verification for non-legacy addresses, signature verification would fail because Unisat generates `ecdsa` signatures and verification in Ordit-SDK is done using bip322-js (for non-legacy signatures) which uses [bip322 strategy](https://bips.xyz/322).

Reference: https://github.com/sadoprotocol/ordit-sdk/pull/92

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
