### PR TITLE
fix(sdk): wrong exports during build and incorrect nested-segwit name

### DIFF
--- a/packages/sdk/src/api/jsonrpc.ts
+++ b/packages/sdk/src/api/jsonrpc.ts
@@ -1,6 +1,6 @@
 import fetch from "cross-fetch";
 
-import { apiConfig } from "../config";
+import { API_CONFIG } from "../config";
 import { OrditSDKError } from "../errors";
 
 type JsonRpcId = string | number | null;
@@ -113,7 +113,7 @@ export const rpc = {
   get id() {
     return Math.floor(Math.random() * 100000);
   },
-  mainnet: new JsonRpc(getRpcUrl(apiConfig.apis.mainnet.batter)),
-  testnet: new JsonRpc(getRpcUrl(apiConfig.apis.testnet.batter)),
-  regtest: new JsonRpc(getRpcUrl(apiConfig.apis.regtest.batter)),
+  mainnet: new JsonRpc(getRpcUrl(API_CONFIG.apis.mainnet.batter)),
+  testnet: new JsonRpc(getRpcUrl(API_CONFIG.apis.testnet.batter)),
+  regtest: new JsonRpc(getRpcUrl(API_CONFIG.apis.regtest.batter)),
 } as const;

--- a/packages/sdk/src/browser-wallets/unisat/index.ts
+++ b/packages/sdk/src/browser-wallets/unisat/index.ts
@@ -151,3 +151,6 @@ async function signMessage(
 }
 
 export { getAddresses, isInstalled, signMessage, signPsbt };
+
+export * from "../types";
+export * from "./types";

--- a/packages/sdk/src/browser-wallets/xverse/index.ts
+++ b/packages/sdk/src/browser-wallets/xverse/index.ts
@@ -265,3 +265,6 @@ async function signMessage(
 }
 
 export { getAddresses, isInstalled, signMessage, signPsbt };
+
+export * from "../types";
+export * from "./types";

--- a/packages/sdk/src/config/index.ts
+++ b/packages/sdk/src/config/index.ts
@@ -1,4 +1,4 @@
-export const apiConfig = {
+export const API_CONFIG = {
   version: "0.0.0.10",
   apis: {
     mainnet: {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,6 +6,7 @@ import { initEccLib } from "bitcoinjs-lib";
 initEccLib(ecc);
 
 export * from "./addresses";
+export * from "./errors";
 export * from "./modules";
 export * from "./ordinals/index";
 export * from "./transactions";

--- a/packages/sdk/unisat.d.ts
+++ b/packages/sdk/unisat.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/browser-wallets/unisat/index";
+export * from "./dist/unisat";

--- a/packages/sdk/xverse.d.ts
+++ b/packages/sdk/xverse.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/browser-wallets/xverse/index";
+export * from "./dist/xverse";


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Required for ord-connect
- Fix incorrect export type for unisat / xverse during package publishing
- Export types within index
- Export errors
- Change to variable name `apiConfig` to `API_CONFIG`
- Fix incorrect `nested-segwit` name in `transactions/helper` which was already changed to `p2sh-p2wpkh` during initial migration

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
