### PR TITLE
fix(unisat): wrap errors

### DIFF
--- a/apps/docs/docs/api/browser-wallets.mdx
+++ b/apps/docs/docs/api/browser-wallets.mdx
@@ -122,6 +122,7 @@ Gets a list of addresses for the browser wallet if authorized.
 
 - `BrowserWalletNotInstalledError` Wallet is not installed
 - `BrowserWalletRequestCancelledByUserError` if user cancels the request on wallet popup
+- `OrditSDKError` Internal error
 
 ### signPsbt
 

--- a/packages/sdk/src/browser-wallets/unisat/__tests__/index.spec.ts
+++ b/packages/sdk/src/browser-wallets/unisat/__tests__/index.spec.ts
@@ -76,7 +76,7 @@ describe("Unisat Wallet", () => {
       expect(getAddresses("testnet")).resolves.toEqual([mockData]);
     });
 
-    test("should throw error on user cancel or reject", () => {
+    test("should throw error when user rejects or cancels request", () => {
       const mockData: WalletAddress = {
         publicKey:
           "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",

--- a/packages/sdk/src/browser-wallets/unisat/__tests__/index.spec.ts
+++ b/packages/sdk/src/browser-wallets/unisat/__tests__/index.spec.ts
@@ -3,6 +3,7 @@ import { networks, Psbt } from "bitcoinjs-lib";
 
 import {
   BrowserWalletExtractTxFromNonFinalizedPsbtError,
+  BrowserWalletRequestCancelledByUserError,
   OrditSDKError,
 } from "../../../errors";
 import { WalletAddress } from "../../types";
@@ -66,6 +67,38 @@ describe("Unisat Wallet", () => {
         getPublicKey: vi.fn().mockResolvedValue(mockData.publicKey),
       });
       expect(getAddresses("testnet")).resolves.toEqual([mockData]);
+    });
+
+    test("should throw error on user cancel or reject", () => {
+      const mockData: WalletAddress = {
+        publicKey:
+          "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        address: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        format: "segwit",
+      };
+      const network = "testnet";
+      const UNISAT_ERROR = {
+        code: 4001,
+        message: "User rejected the request.",
+      };
+      const CANCELLED_BY_USER_ERROR =
+        new BrowserWalletRequestCancelledByUserError();
+
+      vi.stubGlobal("unisat", {
+        getNetwork: vi
+          .fn()
+          .mockResolvedValue(NETWORK_TO_UNISAT_NETWORK[network]),
+        requestAccounts: vi.fn().mockImplementation(async () => {
+          // unisat uses eth-rpc-providers which does not throw Error object
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw UNISAT_ERROR;
+        }),
+        getPublicKey: vi.fn().mockResolvedValue(mockData.publicKey),
+      });
+
+      expect(getAddresses(network)).rejects.toThrowError(
+        CANCELLED_BY_USER_ERROR,
+      );
     });
   });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Wraps errors thrown by unisat to ordit sdk errors, so that ord-connect doesn't leak the errors

Required for ord-connect

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
