### PR TITLE
fix(xverse): type and log error

### DIFF
--- a/packages/sdk/src/browser-wallets/xverse/index.ts
+++ b/packages/sdk/src/browser-wallets/xverse/index.ts
@@ -151,6 +151,8 @@ async function signPsbt(
           try {
             signedPsbt.finalizeInput(index);
           } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error("Sign psbt error", error);
             throw new OrditSDKError("Failed to finalize input");
           }
         });

--- a/packages/sdk/src/browser-wallets/xverse/types.ts
+++ b/packages/sdk/src/browser-wallets/xverse/types.ts
@@ -1,4 +1,5 @@
 import type { BrowserWalletNetwork } from "../../config/types";
+import { InputsToSign } from "../../inscription/types";
 
 export type XverseNetwork = "Mainnet" | "Testnet";
 
@@ -6,8 +7,5 @@ export type XverseSignPSBTOptions = {
   finalize?: boolean;
   extractTx?: boolean;
   network: BrowserWalletNetwork;
-  inputsToSign: Array<{
-    address: string;
-    signingIndexes: number[];
-  }>;
+  inputsToSign: InputsToSign[];
 };

--- a/packages/sdk/src/transactions/PSBTBuilder.ts
+++ b/packages/sdk/src/transactions/PSBTBuilder.ts
@@ -180,7 +180,7 @@ export class PSBTBuilder extends FeeEstimator {
   get inputsToSign() {
     const instantTradeSellerFlow =
       this.instantTradeMode && !this.autoAdjustment;
-    return this.psbt.txInputs.reduce(
+    return this.psbt.txInputs.reduce<InputsToSign>(
       (acc, _, index) => {
         if (
           !this.instantTradeMode ||
@@ -200,7 +200,7 @@ export class PSBTBuilder extends FeeEstimator {
       {
         address: this.address,
         signingIndexes: [],
-      } as InputsToSign,
+      },
     );
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Fix incorrect Xverse input type (missing `sigHash`)
- Log Xverse sign psbt error (not using templated strings since I need the callstack)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
