### PR TITLE
fix(xverse): signing issue

### DIFF
--- a/packages/sdk/src/browser-wallets/xverse/index.ts
+++ b/packages/sdk/src/browser-wallets/xverse/index.ts
@@ -1,4 +1,5 @@
-import { Psbt } from "bitcoinjs-lib";
+import * as ecc from "@bitcoinerlab/secp256k1";
+import { initEccLib, Psbt } from "bitcoinjs-lib";
 import {
   AddressPurpose,
   getAddress,
@@ -25,6 +26,11 @@ import type { BrowserWalletSignResponse, WalletAddress } from "../types";
 import { NETWORK_TO_BITCOIN_NETWORK_TYPE } from "./constants";
 import type { XverseSignPSBTOptions } from "./types";
 import { fromXOnlyToFullPubkey } from "./utils";
+
+// Included here as browser-wallets is an individual entry-point.
+// Required for all signing operations to function within xverse since inputs need to be finalized.
+// This function will manage its own instance.
+initEccLib(ecc);
 
 /**
  * Checks if the browser wallet extension is installed.

--- a/packages/sdk/src/fee/__tests__/FeeEstimator.spec.ts
+++ b/packages/sdk/src/fee/__tests__/FeeEstimator.spec.ts
@@ -1,8 +1,15 @@
+import * as ecc from "@bitcoinerlab/secp256k1";
+import { initEccLib } from "bitcoinjs-lib";
+
 import { OrditSDKError } from "../../errors";
 import { FeeEstimator } from "../FeeEstimator";
 import { createMockPsbt } from "./utils";
 
 describe("FeeEstimator", () => {
+  beforeAll(() => {
+    initEccLib(ecc);
+  });
+
   describe("constructor", () => {
     const INVALID_FEE_RATE_ERROR = new OrditSDKError("Invalid feeRate");
 

--- a/packages/sdk/src/fee/__tests__/utils.ts
+++ b/packages/sdk/src/fee/__tests__/utils.ts
@@ -1,5 +1,4 @@
-import * as ecc from "@bitcoinerlab/secp256k1";
-import { initEccLib, networks, Psbt } from "bitcoinjs-lib";
+import { networks, Psbt } from "bitcoinjs-lib";
 
 import { AddressFormat } from "../../addresses/types";
 import { P2SH_P2WPKH, P2TR, P2WPKH } from "../__fixtures__/psbt.fixture";
@@ -25,7 +24,6 @@ function createMockPsbt(format: Exclude<AddressFormat, "legacy">) {
         .addOutputs(P2WPKH.OUTPUTS);
     case "taproot":
       // taproot psbt script contains OP_CHECKSEQUENCEVERIFY, requires Ecc lib
-      initEccLib(ecc);
       return new Psbt({ network: networks.regtest })
         .addInputs(P2TR.INPUTS)
         .addOutputs(P2TR.OUTPUTS);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Fix xverse signing issue
- Move initEccLib to test case initialisation so that other test cases will throw an error explicitly when calling Psbt functions that use the ecc lib

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


#### Additional comments?:
