### PR TITLE
fix(p2wsh): don't throw error on p2wsh address check

### DIFF
--- a/packages/sdk/src/addresses/__tests__/index.spec.ts
+++ b/packages/sdk/src/addresses/__tests__/index.spec.ts
@@ -18,6 +18,7 @@ describe("addresses", () => {
         segwit: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
         taproot:
           "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297",
+        p2wsh: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
       },
       [TESTNET]: {
         legacy: "mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn",
@@ -25,6 +26,7 @@ describe("addresses", () => {
         segwit: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
         taproot:
           "tb1p3gqcaq2xs0qzm5wvkht64xppcz9h5k0q2q97kf6n80gu7v037dksatsuhz",
+        p2wsh: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
       },
       [REGTEST]: {
         legacy: "mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn",
@@ -32,6 +34,8 @@ describe("addresses", () => {
         segwit: "bcrt1q3v3tujtu443ukyhvzsqmnjgxfv4yevvhcqyqak",
         taproot:
           "bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6",
+        p2wsh:
+          "bcrt1qpj7ehqa8q585n3srsl7a5njfjemd2nagdak5qflswkxd9c7fakxqgg545v",
       },
     };
 
@@ -49,6 +53,7 @@ describe("addresses", () => {
       expect(getAddressFormat(ADDRESSES[network].taproot, network)).toBe(
         "taproot",
       );
+      expect(getAddressFormat(ADDRESSES[network].p2wsh, network)).toBe("p2wsh");
     });
 
     test("should return correct address format for testnet", () => {
@@ -65,6 +70,7 @@ describe("addresses", () => {
       expect(getAddressFormat(ADDRESSES[network].taproot, network)).toBe(
         "taproot",
       );
+      expect(getAddressFormat(ADDRESSES[network].p2wsh, network)).toBe("p2wsh");
 
       // non-bech32 addresses from regtest will work on testnet
       expect(() =>
@@ -89,6 +95,7 @@ describe("addresses", () => {
       expect(getAddressFormat(ADDRESSES[network].taproot, network)).toBe(
         "taproot",
       );
+      expect(getAddressFormat(ADDRESSES[network].p2wsh, network)).toBe("p2wsh");
 
       // non-bech32 addresses from testnet will work on regtest
       expect(() =>
@@ -119,6 +126,9 @@ describe("addresses", () => {
         getAddressFormat(ADDRESSES[TESTNET].taproot, MAINNET),
       ).toThrowError(INVALID_ADDRESS_ERROR);
       expect(() =>
+        getAddressFormat(ADDRESSES[TESTNET].p2wsh, MAINNET),
+      ).toThrowError(INVALID_ADDRESS_ERROR);
+      expect(() =>
         getAddressFormat(ADDRESSES[REGTEST].legacy, MAINNET),
       ).toThrowError(INVALID_ADDRESS_ERROR);
       expect(() =>
@@ -129,6 +139,9 @@ describe("addresses", () => {
       ).toThrowError(INVALID_ADDRESS_ERROR);
       expect(() =>
         getAddressFormat(ADDRESSES[REGTEST].taproot, MAINNET),
+      ).toThrowError(INVALID_ADDRESS_ERROR);
+      expect(() =>
+        getAddressFormat(ADDRESSES[REGTEST].p2wsh, MAINNET),
       ).toThrowError(INVALID_ADDRESS_ERROR);
     });
 
@@ -152,10 +165,16 @@ describe("addresses", () => {
         getAddressFormat(ADDRESSES[MAINNET].taproot, TESTNET),
       ).toThrowError(INVALID_ADDRESS_ERROR);
       expect(() =>
+        getAddressFormat(ADDRESSES[MAINNET].p2wsh, TESTNET),
+      ).toThrowError(INVALID_ADDRESS_ERROR);
+      expect(() =>
         getAddressFormat(ADDRESSES[REGTEST].segwit, TESTNET),
       ).toThrowError(INVALID_ADDRESS_ERROR);
       expect(() =>
         getAddressFormat(ADDRESSES[REGTEST].taproot, TESTNET),
+      ).toThrowError(INVALID_ADDRESS_ERROR);
+      expect(() =>
+        getAddressFormat(ADDRESSES[REGTEST].p2wsh, TESTNET),
       ).toThrowError(INVALID_ADDRESS_ERROR);
     });
 
@@ -179,10 +198,16 @@ describe("addresses", () => {
         getAddressFormat(ADDRESSES[MAINNET].taproot, REGTEST),
       ).toThrowError(INVALID_ADDRESS_ERROR);
       expect(() =>
+        getAddressFormat(ADDRESSES[MAINNET].p2wsh, REGTEST),
+      ).toThrowError(INVALID_ADDRESS_ERROR);
+      expect(() =>
         getAddressFormat(ADDRESSES[TESTNET].segwit, REGTEST),
       ).toThrowError(INVALID_ADDRESS_ERROR);
       expect(() =>
         getAddressFormat(ADDRESSES[TESTNET].taproot, REGTEST),
+      ).toThrowError(INVALID_ADDRESS_ERROR);
+      expect(() =>
+        getAddressFormat(ADDRESSES[TESTNET].p2wsh, REGTEST),
       ).toThrowError(INVALID_ADDRESS_ERROR);
     });
   });

--- a/packages/sdk/src/addresses/constants.ts
+++ b/packages/sdk/src/addresses/constants.ts
@@ -4,6 +4,7 @@ import type { AddressFormat, AddressType } from "./types";
 export const ADDRESS_TYPE_TO_FORMAT: Record<AddressType, AddressFormat> = {
   p2pkh: "legacy",
   p2sh: "p2sh-p2wpkh",
+  p2wsh: "p2wsh",
   p2wpkh: "segwit",
   p2tr: "taproot",
 } as const;

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -79,12 +79,8 @@ function getAddressFromBip32PublicKey(
 export function getAddressesFromPublicKey(
   publicKey: string | Buffer,
   network: Network = "mainnet",
-  type: AddressType | "all" = "all",
+  type: Exclude<AddressType, "p2wsh"> | "all" = "all",
 ): Address[] {
-  if (type === "p2wsh") {
-    throw new OrditSDKError("P2WSH is not supported");
-  }
-
   const publicKeyBuffer = Buffer.isBuffer(publicKey)
     ? publicKey
     : Buffer.from(publicKey, "hex");

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -13,10 +13,6 @@ import { ADDRESS_TYPE_TO_FORMAT } from "./constants";
 import type { Address, AddressFormat, AddressType } from "./types";
 
 function getAddressFormatFromType(type: AddressTypeEnum): AddressFormat {
-  if (type === AddressTypeEnum.p2wsh) {
-    // p2wsh is not supported by browser wallets
-    throw new OrditSDKError("Invalid address");
-  }
   return ADDRESS_TYPE_TO_FORMAT[type];
 }
 
@@ -90,6 +86,10 @@ export function getAddressesFromPublicKey(
   network: Network = "mainnet",
   type: AddressType | "all" = "all",
 ): Address[] {
+  if (type === "p2wsh") {
+    throw new OrditSDKError("P2WSH is not supported");
+  }
+
   const publicKeyBuffer = Buffer.isBuffer(publicKey)
     ? publicKey
     : Buffer.from(publicKey, "hex");
@@ -100,7 +100,10 @@ export function getAddressesFromPublicKey(
   );
 
   if (type === "all") {
-    const addressTypes = Object.keys(ADDRESS_TYPE_TO_FORMAT) as AddressType[];
+    // p2wsh is not supported by browser wallets
+    const addressTypes = (
+      Object.keys(ADDRESS_TYPE_TO_FORMAT) as AddressType[]
+    ).filter((addressType) => addressType !== "p2wsh");
     return addressTypes.map((addressType) =>
       getAddressFromBip32PublicKey(bip32PublicKey, network, addressType),
     );

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -1,5 +1,4 @@
 import {
-  AddressType as AddressTypeEnum,
   getAddressInfo,
   Network as NetworkEnum,
   validate,
@@ -12,10 +11,6 @@ import { createPayment, getNetwork } from "../utils";
 import { ADDRESS_TYPE_TO_FORMAT } from "./constants";
 import type { Address, AddressFormat, AddressType } from "./types";
 
-function getAddressFormatFromType(type: AddressTypeEnum): AddressFormat {
-  return ADDRESS_TYPE_TO_FORMAT[type];
-}
-
 function getAddressFormatForRegTest(address: string): AddressFormat {
   try {
     const { type, network: validatedNetwork, bech32 } = getAddressInfo(address);
@@ -26,7 +21,7 @@ function getAddressFormatForRegTest(address: string): AddressFormat {
       // This type Error is intentional, we'll forward the top-level one anyway
       throw new Error("Invalid address");
     }
-    return getAddressFormatFromType(type);
+    return ADDRESS_TYPE_TO_FORMAT[type];
   } catch (_) {
     throw new OrditSDKError("Invalid address");
   }
@@ -47,7 +42,7 @@ export function getAddressFormat(
   }
 
   const { type } = getAddressInfo(address);
-  return getAddressFormatFromType(type);
+  return ADDRESS_TYPE_TO_FORMAT[type];
 }
 
 function getTaprootAddressFromBip32PublicKey(

--- a/packages/sdk/src/addresses/types.ts
+++ b/packages/sdk/src/addresses/types.ts
@@ -1,6 +1,11 @@
-export type AddressType = "p2pkh" | "p2sh" | "p2wpkh" | "p2tr";
+export type AddressType = "p2pkh" | "p2sh" | "p2wsh" | "p2wpkh" | "p2tr";
 
-export type AddressFormat = "legacy" | "p2sh-p2wpkh" | "segwit" | "taproot";
+export type AddressFormat =
+  | "legacy"
+  | "p2sh-p2wpkh"
+  | "p2wsh"
+  | "segwit"
+  | "taproot";
 
 export type Address = {
   /**

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -70,7 +70,12 @@ export function getDerivationPath(
   account = 0,
   addressIndex = 0,
 ) {
-  const pathFormat: Record<AddressFormat, string> = {
+  if (formatType === "p2wsh") {
+    // No supported derivation path
+    return "";
+  }
+
+  const pathFormat: Record<Exclude<AddressFormat, "p2wsh">, string> = {
     legacy: `m/44'/0'/${account}'/0/${addressIndex}`,
     "p2sh-p2wpkh": `m/49'/0'/${account}'/0/${addressIndex}`,
     segwit: `m/84'/0'/${account}'/0/${addressIndex}`,
@@ -298,7 +303,7 @@ export const isP2WSHScript = (
 ): IsBitcoinPaymentResponse => {
   const p2wsh = isPaymentFactory(payments.p2wsh, network)(script);
   return {
-    type: "p2sh",
+    type: "p2wsh",
     payload: p2wsh,
   };
 };

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -297,16 +297,6 @@ export const isP2WPKH = (
   };
 };
 
-export const isP2WSHScript = (
-  script: Buffer,
-  network: Network,
-): IsBitcoinPaymentResponse => {
-  const p2wsh = isPaymentFactory(payments.p2wsh, network)(script);
-  return {
-    type: "p2wsh",
-    payload: p2wsh,
-  };
-};
 export const isP2SHScript = (
   script: Buffer,
   network: Network,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Allows P2WSH addresses to be considered as valid. However, we won't allow P2WSH in scripts

- P2WSH addresses were being considered as invalid which wasn't identical to the bitcoin-address-validation library

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
