### PR TITLE
fix(sdk): detection of magic eden wallet

### DIFF
--- a/apps/browser-tests/package.json
+++ b/apps/browser-tests/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@ordzaar/ordit-sdk": "workspace:*",
+    "@wallet-standard/base": "^1.0.1",
+    "@wallet-standard/react": "0.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/apps/browser-tests/package.json
+++ b/apps/browser-tests/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@ordzaar/ordit-sdk": "workspace:*",
     "@wallet-standard/base": "^1.0.1",
-    "@wallet-standard/react": "0.1.4",
+    "@wallet-standard/core": "^1.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/apps/browser-tests/src/App.tsx
+++ b/apps/browser-tests/src/App.tsx
@@ -366,6 +366,7 @@ function App() {
           <Transactions
             provider={provider}
             connectedAddresses={connectedAddresses}
+            satsConnectWallets={wallets as Wallet[]}
           />
         </>
       ) : null}

--- a/apps/browser-tests/src/App.tsx
+++ b/apps/browser-tests/src/App.tsx
@@ -4,9 +4,9 @@ import * as leather from "@ordzaar/ordit-sdk/leather";
 import * as magiceden from "@ordzaar/ordit-sdk/magiceden";
 import * as unisat from "@ordzaar/ordit-sdk/unisat";
 import * as xverse from "@ordzaar/ordit-sdk/xverse";
-import { useWallets } from "@wallet-standard/react";
 import { MagicEdenWallet } from "@ordzaar/ordit-sdk/magiceden";
 import { Wallet } from "@wallet-standard/base";
+import { getWallets } from "@wallet-standard/core";
 
 import { RadioInput } from "./components/RadioInput";
 import { Select } from "./components/Select";
@@ -273,7 +273,8 @@ function App() {
   const [connectedAddresses, setConnectedAddresses] = useState<
     Address[] | undefined
   >();
-  const { wallets } = useWallets();
+  const { get, on } = getWallets();
+  const wallets = get();
 
   const handleConnect = useCallback(async () => {
     if (provider === "unisat") {

--- a/apps/browser-tests/src/main.tsx
+++ b/apps/browser-tests/src/main.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { WalletStandardProvider } from "@wallet-standard/react";
 
 import App from "./App";
 
@@ -8,8 +7,6 @@ import "./style.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <WalletStandardProvider>
-      <App />
-    </WalletStandardProvider>
+    <App />
   </React.StrictMode>,
 );

--- a/apps/browser-tests/src/main.tsx
+++ b/apps/browser-tests/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { WalletStandardProvider } from "@wallet-standard/react";
 
 import App from "./App";
 
@@ -7,6 +8,8 @@ import "./style.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <WalletStandardProvider>
+      <App />
+    </WalletStandardProvider>
   </React.StrictMode>,
 );

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@bitcoinerlab/secp256k1": "1.1.1",
+    "@wallet-standard/base": "^1.0.1",
     "bignumber.js": "9.1.2",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/packages/sdk/src/browser-wallets/magiceden/index.ts
+++ b/packages/sdk/src/browser-wallets/magiceden/index.ts
@@ -34,13 +34,17 @@ export interface MagicEdenWallet extends Wallet {
  * @returns `true` if installed, `false` otherwise.
  * @throws {OrditSDKError} Function is called outside a browser without `window` object
  */
-function isInstalled(): boolean {
+async function isInstalled(
+  getMeProvider: () => Promise<BitcoinProvider>,
+): Promise<boolean> {
   if (typeof window === "undefined") {
     throw new OrditSDKError("Cannot call this function outside a browser");
   }
 
+  const magicEdenProvider = await getMeProvider();
+
   return (
-    typeof (window as MagicEdenWindow).BitcoinProvider?.isMagicEden !==
+    typeof (magicEdenProvider as MagicEdenBitcoinProvider).isMagicEden !==
     "undefined"
   );
 }
@@ -49,7 +53,7 @@ async function getAddresses(
   getMeProvider: () => Promise<BitcoinProvider>,
   network: BrowserWalletNetwork = "mainnet",
 ): Promise<WalletAddress[]> {
-  if (!isInstalled()) {
+  if (!isInstalled(getMeProvider)) {
     throw new BrowserWalletNotInstalledError(
       "Magic Eden not installed or set as prioritised wallet.",
     );
@@ -68,7 +72,7 @@ async function signPsbt(
     inputsToSign,
   }: SatsConnectSignPSBTOptions = { network: "mainnet", inputsToSign: [] },
 ): Promise<BrowserWalletSignResponse> {
-  if (!isInstalled()) {
+  if (!isInstalled(getMeProvider)) {
     throw new BrowserWalletNotInstalledError(
       "Magic Eden not installed or set as prioritised wallet.",
     );
@@ -88,7 +92,7 @@ async function signMessage(
   address: string,
   network: BrowserWalletNetwork = "mainnet",
 ): Promise<BrowserWalletSignResponse> {
-  if (!isInstalled()) {
+  if (!isInstalled(getMeProvider)) {
     throw new BrowserWalletNotInstalledError(
       "Magic Eden not installed or set as prioritised wallet.",
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,9 @@ importers:
       '@wallet-standard/base':
         specifier: ^1.0.1
         version: 1.0.1
-      '@wallet-standard/react':
-        specifier: 0.1.4
-        version: 0.1.4(react-dom@18.2.0)(react@18.2.0)
+      '@wallet-standard/core':
+        specifier: ^1.0.3
+        version: 1.0.3
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -175,13 +175,13 @@ importers:
         version: 13.4.1
       vite-plugin-dts:
         specifier: ^3.7.2
-        version: 3.7.2(@types/node@20.9.0)(typescript@5.3.3)(vite@5.0.12)
+        version: 3.7.2(@types/node@20.9.0)(typescript@5.3.3)(vite@4.5.0)
       vite-plugin-eslint:
         specifier: ^1.8.1
-        version: 1.8.1(eslint@8.56.0)(vite@5.0.12)
+        version: 1.8.1(eslint@8.56.0)(vite@4.5.0)
       vite-plugin-node-polyfills:
         specifier: ^0.21.0
-        version: 0.21.0(vite@5.0.12)
+        version: 0.21.0(vite@4.5.0)
 
 packages:
 
@@ -4536,11 +4536,14 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@wallet-standard/experimental-features@0.1.1:
-    resolution: {integrity: sha512-WKtnET1okeDACTbxmePGOGaIUrGvlu/DestLZvZ/ddFpUKw7nokkbinX/gHzsuAC9WGtLyhqLSppAHzN+vAAaQ==}
+  /@wallet-standard/core@1.0.3:
+    resolution: {integrity: sha512-Jb33IIjC1wM1HoKkYD7xQ6d6PZ8EmMZvyc8R7dFgX66n/xkvksVTW04g9yLvQXrLFbcIjHrCxW6TXMhvpsAAzg==}
     engines: {node: '>=16'}
     dependencies:
+      '@wallet-standard/app': 1.0.1
       '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.3
+      '@wallet-standard/wallet': 1.0.1
     dev: false
 
   /@wallet-standard/features@1.0.3:
@@ -4550,29 +4553,11 @@ packages:
       '@wallet-standard/base': 1.0.1
     dev: false
 
-  /@wallet-standard/react-core@0.1.4(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-RZNx0NDs/iTINAKZ9W1K0XY0UScH70QRxbkG6a4OZAN6Ry8R+ZzZUfNYau65Re1X3MRVL6Uy64EfQbUlZthTiA==}
+  /@wallet-standard/wallet@1.0.1:
+    resolution: {integrity: sha512-qkhJeuQU2afQTZ02yMZE5SFc91Fo3hyFjFkpQglHudENNyiSG0oUKcIjky8X32xVSaumgTZSQUAzpXnCTWHzKQ==}
     engines: {node: '>=16'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
     dependencies:
-      '@wallet-standard/app': 1.0.1
       '@wallet-standard/base': 1.0.1
-      '@wallet-standard/experimental-features': 0.1.1
-      '@wallet-standard/features': 1.0.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
-  /@wallet-standard/react@0.1.4(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-LEI/qF6+P4YqyeGOyxzMhbFpIo7JcQ3tEZUOIKoBfvkZpDN2n/Ww60KjCGUMhXhnrEDLMpyfrKYJJ0qLacENQw==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@wallet-standard/react-core': 0.1.4(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: false
 
   /@webassemblyjs/ast@1.11.6:
@@ -13456,7 +13441,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@3.7.2(@types/node@20.9.0)(typescript@5.3.3)(vite@5.0.12):
+  /vite-plugin-dts@3.7.2(@types/node@20.9.0)(typescript@5.3.3)(vite@4.5.0):
     resolution: {integrity: sha512-kg//1nDA01b8rufJf4TsvYN8LMkdwv0oBYpiQi6nRwpHyue+wTlhrBiqgipdFpMnW1oOYv6ywmzE5B0vg6vSEA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -13472,7 +13457,7 @@ packages:
       debug: 4.3.4
       kolorist: 1.8.0
       typescript: 5.3.3
-      vite: 5.0.12(@types/node@20.9.0)
+      vite: 4.5.0(@types/node@20.9.0)
       vue-tsc: 1.8.27(typescript@5.3.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -13480,7 +13465,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-eslint@1.8.1(eslint@8.56.0)(vite@5.0.12):
+  /vite-plugin-eslint@1.8.1(eslint@8.56.0)(vite@4.5.0):
     resolution: {integrity: sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==}
     peerDependencies:
       eslint: '>=7'
@@ -13490,7 +13475,19 @@ packages:
       '@types/eslint': 8.44.7
       eslint: 8.56.0
       rollup: 2.79.1
-      vite: 5.0.12(@types/node@20.9.0)
+      vite: 4.5.0(@types/node@20.9.0)
+    dev: true
+
+  /vite-plugin-node-polyfills@0.21.0(vite@4.5.0):
+    resolution: {integrity: sha512-Sk4DiKnmxN8E0vhgEhzLudfJQfaT8k4/gJ25xvUPG54KjLJ6HAmDKbr4rzDD/QWEY+Lwg80KE85fGYBQihEPQA==}
+    peerDependencies:
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5
+      node-stdlib-browser: 1.2.0
+      vite: 4.5.0(@types/node@20.9.0)
+    transitivePeerDependencies:
+      - rollup
     dev: true
 
   /vite-plugin-node-polyfills@0.21.0(vite@5.0.12):
@@ -13569,42 +13566,6 @@ packages:
       terser:
         optional: true
     dependencies:
-      esbuild: 0.19.12
-      postcss: 8.4.33
-      rollup: 4.9.6
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /vite@5.0.12(@types/node@20.9.0):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.9.0
       esbuild: 0.19.12
       postcss: 8.4.33
       rollup: 4.9.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
       '@ordzaar/ordit-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      '@wallet-standard/base':
+        specifier: ^1.0.1
+        version: 1.0.1
+      '@wallet-standard/react':
+        specifier: 0.1.4
+        version: 0.1.4(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -65,7 +71,7 @@ importers:
         version: 18.2.19
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@4.5.0)
+        version: 4.2.1(vite@5.0.12)
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.0(eslint@8.56.0)
@@ -74,7 +80,7 @@ importers:
         version: 0.4.5(eslint@8.56.0)
       vite-plugin-node-polyfills:
         specifier: ^0.21.0
-        version: 0.21.0(vite@4.5.0)
+        version: 0.21.0(vite@5.0.12)
 
   apps/docs:
     dependencies:
@@ -121,6 +127,9 @@ importers:
       '@bitcoinerlab/secp256k1':
         specifier: 1.1.1
         version: 1.1.1
+      '@wallet-standard/base':
+        specifier: ^1.0.1
+        version: 1.0.1
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -172,7 +181,7 @@ importers:
         version: 1.8.1(eslint@8.56.0)(vite@5.0.12)
       vite-plugin-node-polyfills:
         specifier: ^0.21.0
-        version: 0.21.0(vite@4.5.0)
+        version: 0.21.0(vite@5.0.12)
 
 packages:
 
@@ -3267,7 +3276,7 @@ packages:
       eslint-config-next: 14.1.0(eslint@8.56.0)(typescript@5.3.3)
       eslint-config-prettier: 9.1.0(eslint@8.56.0)
       eslint-plugin-cypress: 2.15.1(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-node: 11.1.0(eslint@8.56.0)
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.56.0)(prettier@3.2.5)
@@ -4378,7 +4387,7 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@vitejs/plugin-react@4.2.1(vite@4.5.0):
+  /@vitejs/plugin-react@4.2.1(vite@5.0.12):
     resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4389,7 +4398,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 4.5.0(@types/node@20.9.0)
+      vite: 5.0.12
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4514,6 +4523,57 @@ packages:
   /@vue/shared@3.3.8:
     resolution: {integrity: sha512-8PGwybFwM4x8pcfgqEQFy70NaQxASvOC5DJwLQfpArw1UDfUXrJkdxD3BhVTMS+0Lef/TU7YO0Jvr0jJY8T+mw==}
     dev: true
+
+  /@wallet-standard/app@1.0.1:
+    resolution: {integrity: sha512-LnLYq2Vy2guTZ8GQKKSXQK3+FRGPil75XEdkZqE6fiLixJhZJoJa5hT7lXxwe0ykVTt9LEThdTbOpT7KadS26Q==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.1
+    dev: false
+
+  /@wallet-standard/base@1.0.1:
+    resolution: {integrity: sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==}
+    engines: {node: '>=16'}
+    dev: false
+
+  /@wallet-standard/experimental-features@0.1.1:
+    resolution: {integrity: sha512-WKtnET1okeDACTbxmePGOGaIUrGvlu/DestLZvZ/ddFpUKw7nokkbinX/gHzsuAC9WGtLyhqLSppAHzN+vAAaQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.1
+    dev: false
+
+  /@wallet-standard/features@1.0.3:
+    resolution: {integrity: sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.1
+    dev: false
+
+  /@wallet-standard/react-core@0.1.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-RZNx0NDs/iTINAKZ9W1K0XY0UScH70QRxbkG6a4OZAN6Ry8R+ZzZUfNYau65Re1X3MRVL6Uy64EfQbUlZthTiA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      '@wallet-standard/app': 1.0.1
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/experimental-features': 0.1.1
+      '@wallet-standard/features': 1.0.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@wallet-standard/react@0.1.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-LEI/qF6+P4YqyeGOyxzMhbFpIo7JcQ3tEZUOIKoBfvkZpDN2n/Ww60KjCGUMhXhnrEDLMpyfrKYJJ0qLacENQw==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/react-core': 0.1.4(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+    dev: false
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -6771,7 +6831,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.56.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.2)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       object.assign: 4.1.4
       object.entries: 1.1.7
       semver: 6.3.1
@@ -6789,7 +6849,7 @@ packages:
       '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
     dev: true
 
   /eslint-config-airbnb-typescript@17.1.0(@typescript-eslint/eslint-plugin@7.0.2)(@typescript-eslint/parser@7.0.2)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
@@ -6819,7 +6879,7 @@ packages:
     dependencies:
       eslint: 8.56.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -6985,41 +7045,6 @@ packages:
     dev: true
 
   /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.3.3)
-      array-includes: 3.1.7
-      array.prototype.findlastindex: 1.2.3
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.56.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.19.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      hasown: 2.0.0
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.7
-      object.groupby: 1.0.1
-      object.values: 1.1.7
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13468,26 +13493,14 @@ packages:
       vite: 5.0.12(@types/node@20.9.0)
     dev: true
 
-  /vite-plugin-node-polyfills@0.21.0(vite@4.5.0):
+  /vite-plugin-node-polyfills@0.21.0(vite@5.0.12):
     resolution: {integrity: sha512-Sk4DiKnmxN8E0vhgEhzLudfJQfaT8k4/gJ25xvUPG54KjLJ6HAmDKbr4rzDD/QWEY+Lwg80KE85fGYBQihEPQA==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
       '@rollup/plugin-inject': 5.0.5
       node-stdlib-browser: 1.2.0
-      vite: 4.5.0(@types/node@20.9.0)
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
-  /vite-plugin-node-polyfills@0.19.0(vite@5.0.12):
-    resolution: {integrity: sha512-AhdVxAmVnd1doUlIRGUGV6ZRPfB9BvIwDF10oCOmL742IsvsFIAV4tSMxSfu5e0Px0QeJLgWVOSbtHIvblzqMw==}
-    peerDependencies:
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
-    dependencies:
-      '@rollup/plugin-inject': 5.0.5
-      node-stdlib-browser: 1.2.0
-      vite: 5.0.12(@types/node@20.9.0)
+      vite: 5.0.12
     transitivePeerDependencies:
       - rollup
     dev: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Uses wallet-standard to detect and select Magic Eden Wallet. This ensures Magic Eden Wallet can be selected among the different available sats-connect wallets.
- Update browser-tests to enable testing of Magic Eden Wallet.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
