### PR TITLE
fix(sdk): fix xverse returning compressed pubkey instead of xOnly

### DIFF
--- a/packages/sdk/src/browser-wallets/internal/sats-connect/utils.ts
+++ b/packages/sdk/src/browser-wallets/internal/sats-connect/utils.ts
@@ -1,3 +1,9 @@
 export function fromXOnlyToFullPubkey(xOnly: string): string {
+  const xOnlyBuffer = Buffer.from(xOnly, "hex");
+  // if xOnly is 33 bytes, it's already a full pubkey
+  if (xOnlyBuffer.length === 33) {
+    return xOnly;
+  }
+  // source: https://medium.com/blockstream/reducing-bitcoin-transaction-sizes-with-x-only-pubkeys-f86476af05d7
   return `02${xOnly}`; // prepend y-coord/tie-breaker to x-only
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Xverse normally returns X-only pubkey which is 32 bytes long without `02` or `03` tie-breaker. But when connected with ledger, Xverse returns compressed pubkey with `02` or `03` which makes it 33 bytes long.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
