### PR TITLE
fix(okx): added missing okx wallet sign psbt sighash param

### DIFF
--- a/packages/sdk/src/browser-wallets/okx/index.ts
+++ b/packages/sdk/src/browser-wallets/okx/index.ts
@@ -106,11 +106,12 @@ async function signPsbt(
   const toSignInputs: OKXSignInput[] = [];
 
   inputsToSign.forEach((input) => {
-    const { address, signingIndexes } = input;
+    const { address, signingIndexes, sigHash } = input;
     signingIndexes.forEach((index) => {
       toSignInputs.push({
         index,
         address,
+        sighashTypes: sigHash ? [sigHash] : undefined,
       });
     });
   });

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -47,6 +47,7 @@ type OKXSignInput = {
   index: number;
   address?: string;
   publicKey?: string;
+  sighashTypes?: number[];
 };
 
 type OKXWalletProvider = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Passes `sigHash` from `inputsToSign` to OKX wallet `signPsbt` inputs to sign, ref – https://www.okx.com/web3/build/docs/sdks/chains/bitcoin/provider#signpsbt.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
