### PR TITLE
feat(address-type): add getAddressType

### DIFF
--- a/packages/sdk/src/addresses/__tests__/index.spec.ts
+++ b/packages/sdk/src/addresses/__tests__/index.spec.ts
@@ -48,6 +48,28 @@ describe("addresses", () => {
       },
     };
 
+    const FRACTAL_ADDRESSES: Record<
+      "mainnet" | "testnet",
+      Record<AddressFormat, string>
+    > = {
+      [MAINNET]: {
+        legacy: "17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem",
+        "p2sh-p2wpkh": "3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX",
+        segwit: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+        taproot:
+          "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297",
+        p2wsh: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+      },
+      [TESTNET]: {
+        legacy: "17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem",
+        "p2sh-p2wpkh": "3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX",
+        segwit: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+        taproot:
+          "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297",
+        p2wsh: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+      },
+    };
+
     test("should return correct address format for mainnet", () => {
       const network = MAINNET;
       expect(getAddressFormat(ADDRESSES[network].legacy, network)).toBe(
@@ -138,6 +160,84 @@ describe("addresses", () => {
       expect(() =>
         getAddressFormat(ADDRESSES[REGTEST]["p2sh-p2wpkh"], network),
       ).not.toThrowError(INVALID_ADDRESS_ERROR);
+    });
+
+    test("should return correct address format for fractal bitcoin mainnet", () => {
+      const network = MAINNET;
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].legacy,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("legacy");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network]["p2sh-p2wpkh"],
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("p2sh-p2wpkh");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].segwit,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("segwit");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].taproot,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("taproot");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].p2wsh,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("p2wsh");
+    });
+
+    test("should return correct address format for fractal bitcoin testnet", () => {
+      const network = TESTNET;
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].legacy,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("legacy");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network]["p2sh-p2wpkh"],
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("p2sh-p2wpkh");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].segwit,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("segwit");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].taproot,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("taproot");
+      expect(
+        getAddressFormat(
+          FRACTAL_ADDRESSES[network].p2wsh,
+          network,
+          "fractal-bitcoin",
+        ),
+      ).toBe("p2wsh");
     });
 
     test("should throw an error if address format is not recognised for mainnet", () => {

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -11,7 +11,7 @@ import { createPayment, getNetwork } from "../utils";
 import { ADDRESS_TYPE_TO_FORMAT } from "./constants";
 import type { Address, AddressFormat, AddressType } from "./types";
 
-function getAddressFormatForRegTest(address: string): AddressFormat {
+function getAddressTypeForRegTest(address: string): AddressType {
   try {
     const { type, network: validatedNetwork, bech32 } = getAddressInfo(address);
     if (
@@ -21,19 +21,19 @@ function getAddressFormatForRegTest(address: string): AddressFormat {
       // This type Error is intentional, we'll forward the top-level one anyway
       throw new Error("Invalid address");
     }
-    return ADDRESS_TYPE_TO_FORMAT[type];
+    return type;
   } catch (_) {
     throw new OrditSDKError("Invalid address");
   }
 }
 
-export function getAddressFormat(
+export function getAddressType(
   address: string,
   network: Network,
   chain: Chain = "bitcoin",
-): AddressFormat {
+): AddressType {
   if (chain === "fractal-bitcoin") {
-    if (network === "regtest") {
+    if (network === "regtest" || network === "signet") {
       throw new OrditSDKError("Unsupported operation");
     }
 
@@ -42,13 +42,13 @@ export function getAddressFormat(
     }
 
     const { type } = getAddressInfo(address);
-    return ADDRESS_TYPE_TO_FORMAT[type];
+    return type;
   }
 
   // Separate regtest handling because bitcoin-address-validation treats non-bech32 addresses as testnet addresses,
   // which fail in the validate function.
   if (network === "regtest") {
-    return getAddressFormatForRegTest(address);
+    return getAddressTypeForRegTest(address);
   }
 
   if (
@@ -61,6 +61,15 @@ export function getAddressFormat(
   }
 
   const { type } = getAddressInfo(address);
+  return type;
+}
+
+export function getAddressFormat(
+  address: string,
+  network: Network,
+  chain: Chain = "bitcoin",
+): AddressFormat {
+  const type = getAddressType(address, network, chain);
   return ADDRESS_TYPE_TO_FORMAT[type];
 }
 

--- a/packages/sdk/src/addresses/index.ts
+++ b/packages/sdk/src/addresses/index.ts
@@ -73,6 +73,18 @@ export function getAddressFormat(
   return ADDRESS_TYPE_TO_FORMAT[type];
 }
 
+export function validateAddress(
+  address: string,
+  network: Network,
+  chain: Chain = "bitcoin",
+): boolean {
+  try {
+    return !!getAddressType(address, network, chain);
+  } catch {
+    return false;
+  }
+}
+
 function getTaprootAddressFromBip32PublicKey(
   bip32PublicKey: Buffer,
   network: Network,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Add: `getAddressType`. This function was not migrated from v1 sdk
- Add: `validateAddress`
- Change: `getAddressFormat` to be built on top of `getAddressType`. Functionality is the same.
- Add: Tests for fractal bitcoin address

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
