### PR TITLE
fix(browser-wallet): remove finalize logic from phantom and oyl wallet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - run: npm install -g corepack
-
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - run: npm install -g corepack
+
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - run: corepack enable pnpm
-      - run: pnpm i -g corepack@latest
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+      - run: npm i -g corepack@latest
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+      - run: npm i -g corepack@latest
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+      - run: npm i -g corepack@latest
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+      - run: npm i -g corepack@latest
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: npm i -g corepack@latest
+      - run: npm i -g corepack@latest # Temporary workaround in response to https://github.com/pnpm/pnpm/issues/9029
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: npm i -g corepack@latest
+      - run: npm i -g corepack@latest # Temporary workaround in response to https://github.com/pnpm/pnpm/issues/9029
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: npm i -g corepack@latest
+      - run: npm i -g corepack@latest # Temporary workaround in response to https://github.com/pnpm/pnpm/issues/9029
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: npm i -g corepack@latest
+      - run: npm i -g corepack@latest # Temporary workaround in response to https://github.com/pnpm/pnpm/issues/9029
       - run: corepack enable pnpm
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - run: corepack enable pnpm
+      - run: pnpm i -g corepack@latest
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:

--- a/apps/browser-tests/src/App.tsx
+++ b/apps/browser-tests/src/App.tsx
@@ -157,12 +157,6 @@ function Transactions({
       } else if (provider === "oyl") {
         signPsbtResponse = await oyl.signPsbt(psbt.toPSBT(), {
           network: NETWORK,
-          inputsToSign: [
-            {
-              address: inputAddressInfo.address,
-              signingIndexes: [0],
-            },
-          ],
         });
       } else {
         throw new Error("Unknown provider");

--- a/packages/sdk/src/browser-wallets/oyl/__tests__/index.spec.ts
+++ b/packages/sdk/src/browser-wallets/oyl/__tests__/index.spec.ts
@@ -111,7 +111,7 @@ describe("Oyl Wallet", () => {
 
       expect(MOCK_SIGN_PSBT).toHaveBeenCalledWith({
         psbt: psbt.toHex(),
-        finalize: false,
+        finalize: true,
         broadcast: false,
       });
       expect(signedPsbtResponse).toEqual({
@@ -125,7 +125,6 @@ describe("Oyl Wallet", () => {
       const signedPsbtResponse = await signPsbt(psbt, {
         extractTx: true,
         network: "mainnet",
-        inputsToSign: [],
       });
 
       expect(signedPsbtResponse).toEqual({
@@ -139,7 +138,6 @@ describe("Oyl Wallet", () => {
       const signedPsbtResponse = await signPsbt(psbt, {
         extractTx: false,
         network: "mainnet",
-        inputsToSign: [],
       });
       expect(signedPsbtResponse).toEqual({
         base64: "cHNidP8BAAoCAAAAAAAAAAAAAAAA",
@@ -152,7 +150,6 @@ describe("Oyl Wallet", () => {
       const signedPsbtResponse = await signPsbt(psbt, {
         finalize: true,
         network: "mainnet",
-        inputsToSign: [],
       });
       expect(signedPsbtResponse).toEqual({
         base64: null,
@@ -166,7 +163,6 @@ describe("Oyl Wallet", () => {
         finalize: false,
         extractTx: false,
         network: "mainnet",
-        inputsToSign: [],
       });
       expect(signedPsbtResponse).toEqual({
         base64: "cHNidP8BAAoCAAAAAAAAAAAAAAAA",
@@ -182,7 +178,6 @@ describe("Oyl Wallet", () => {
         signPsbt(psbt, {
           finalize: false,
           network: "mainnet",
-          inputsToSign: [],
         }),
       ).rejects.toThrowError(EXTRACTION_TRANSACTION_NON_FINALIZED_PSBT_ERROR);
     });
@@ -201,7 +196,6 @@ describe("Oyl Wallet", () => {
         signPsbt(psbt, {
           finalize: true,
           network: "mainnet",
-          inputsToSign: [],
         }),
       ).rejects.toThrowError(EXTRACTION_TRANSACTION_NON_FINALIZED_PSBT_ERROR);
     });

--- a/packages/sdk/src/browser-wallets/oyl/types.ts
+++ b/packages/sdk/src/browser-wallets/oyl/types.ts
@@ -1,5 +1,4 @@
 import { BrowserWalletNetwork } from "../../config/types";
-import { InputsToSign } from "../../inscription/types";
 
 export type OylSignPSBTOptions = {
   finalize?: boolean;

--- a/packages/sdk/src/browser-wallets/oyl/types.ts
+++ b/packages/sdk/src/browser-wallets/oyl/types.ts
@@ -5,5 +5,4 @@ export type OylSignPSBTOptions = {
   finalize?: boolean;
   extractTx?: boolean;
   network: BrowserWalletNetwork;
-  inputsToSign: InputsToSign[];
 };

--- a/packages/sdk/src/browser-wallets/phantom/index.ts
+++ b/packages/sdk/src/browser-wallets/phantom/index.ts
@@ -112,6 +112,20 @@ async function signPsbt(
     throw new OrditSDKError("Failed to sign psbt with Phantom Wallet");
   }
 
+  if (finalize) {
+    inputsToSign.forEach((input) => {
+      input.signingIndexes.forEach((index) => {
+        try {
+          signedPsbt.finalizeInput(index);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error("Sign psbt error", error);
+          throw new OrditSDKError("Failed to finalize input");
+        }
+      });
+    });
+  }
+
   if (extractTx) {
     try {
       return {

--- a/packages/sdk/src/browser-wallets/phantom/index.ts
+++ b/packages/sdk/src/browser-wallets/phantom/index.ts
@@ -112,20 +112,6 @@ async function signPsbt(
     throw new OrditSDKError("Failed to sign psbt with Phantom Wallet");
   }
 
-  if (finalize) {
-    inputsToSign.forEach((input) => {
-      input.signingIndexes.forEach((index) => {
-        try {
-          signedPsbt.finalizeInput(index);
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.error("Sign psbt error", error);
-          throw new OrditSDKError("Failed to finalize input");
-        }
-      });
-    });
-  }
-
   if (extractTx) {
     try {
       return {

--- a/packages/sdk/src/browser-wallets/phantom/index.ts
+++ b/packages/sdk/src/browser-wallets/phantom/index.ts
@@ -98,38 +98,18 @@ async function signPsbt(
     throw new BrowserWalletExtractTxFromNonFinalizedPsbtError();
   }
 
-  const toSignInputs: PhantomSignInput[] = [];
-  inputsToSign.forEach((input) => {
-    const { signingIndexes } = input;
-    signingIndexes.forEach(() => {
-      toSignInputs.push(input);
-    });
-  });
-
   let signedPsbtBuffer: Uint8Array;
   let signedPsbt: Psbt;
   try {
     signedPsbtBuffer = await window.phantom.bitcoin.signPSBT(
       Buffer.from(psbt.toHex(), "hex"),
       {
-        inputsToSign: toSignInputs,
+        inputsToSign,
       },
     );
     signedPsbt = Psbt.fromBuffer(Buffer.from(signedPsbtBuffer));
   } catch (err) {
     throw new OrditSDKError("Failed to sign psbt with Phantom Wallet");
-  }
-
-  if (finalize) {
-    toSignInputs.forEach((_input, index) => {
-      try {
-        signedPsbt.finalizeInput(index);
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error("Sign psbt error", error);
-        throw new OrditSDKError("Failed to finalize input");
-      }
-    });
   }
 
   if (extractTx) {

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -160,11 +160,6 @@ type Oyl = {
   }) => Promise<{ psbt: string; txid?: string }>;
 };
 
-type OylSignInput = {
-  sigHash?: number;
-  address: string;
-  signingIndexes?: number[];
-};
 declare module "buffer-reverse" {
   export = (_: Buffer): Buffer => {};
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- As titled
- Use the built in finalize logic on oyl wallet
- Remove custom finalize logic and assume phantom's signPsbt has built-in finalized logic, since it is not properly documented https://docs.phantom.com/bitcoin/sending-a-transaction
- Note: also saw a comment that mention it will send the tx during signPsbt, will be ignoring that for now https://github.com/orgs/phantom/discussions/286 

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
